### PR TITLE
Fix streaming job execution

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - ./batch_processing:/app/batch_processing
       - ./datasets:/app/datasets
       - ./model_serving/models:/app/models
+      - ./streaming:/app/streaming
       - ./.ivy:/ivy
 
   zookeeper:

--- a/run_local.sh
+++ b/run_local.sh
@@ -74,11 +74,14 @@ echo "ML model built and saved to model_serving/models/temperature_model.joblib"
 
 # 8. Run streaming job (background)
 echo "Starting streaming job..."
-docker exec -d namenode spark-submit \
-  --master local[*] /app/streaming/spark_streaming/run_streaming_job.py \
-  --broker localhost:9092 \
+docker exec -d spark \
+  spark-submit \
+  --master local[*] \
+  --conf spark.jars.ivy=/ivy \
+  /app/streaming/spark_streaming/run_streaming_job.py \
+  --broker kafka:9092 \
   --topic climate_data \
-  --output hdfs://localhost:9000/data/streaming
+  --output hdfs://namenode:9000/data/streaming
 
 # 9. Smoke test endpoints
 echo "Testing prediction endpoint..."


### PR DESCRIPTION
## Summary
- mount the streaming directory in the Spark container
- run the streaming Spark job in the Spark container instead of namenode

## Testing
- `python -m py_compile $(git ls-files "*.py")`


------
https://chatgpt.com/codex/tasks/task_b_686e4dc36ddc8330858f68f8862cc5ec