### PR TITLE
Fix CORS error for /predict endpoint

### DIFF
--- a/model_serving/app.py
+++ b/model_serving/app.py
@@ -1,21 +1,15 @@
 from flask import Flask, make_response, request, jsonify
+from flask_cors import CORS
 import joblib
 import pandas as pd
 
 # Load trained model
 model = joblib.load("models/temperature_model.joblib")
 app = Flask(__name__)
+CORS(app, resources={r"/predict": {"origins": "http://localhost:3000"}})
 
 
-@app.after_request
-def add_cors_headers(resp):
-    resp.headers["Access-Control-Allow-Origin"] = "http://localhost:3000"
-    resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
-    resp.headers["Access-Control-Allow-Methods"] = "POST, OPTIONS"
-    return resp
-
-
-@app.route("/predict", methods=["POST"])
+@app.route("/predict", methods=["POST", "OPTIONS"])
 def predict():
     if request.method == "OPTIONS":
         # must still go through after_request to get the CORS headers

--- a/model_serving/requirements.txt
+++ b/model_serving/requirements.txt
@@ -1,4 +1,4 @@
 Flask
+flask-cors
 joblib
-pandas
-scikit-learn
+pandasscikit-learn


### PR DESCRIPTION
## Summary
- enable `flask-cors` in the model serving service
- expose `/predict` route for `OPTIONS` requests
- add `flask-cors` to model serving requirements

## Testing
- `python -m py_compile model_serving/app.py`
- `python -m py_compile flask_app/app.py flask_app/auth.py`
- `python -m py_compile ml_pipeline/model_training.py batch_processing/pandas_batch_job.py ml_pipeline/pandas_preprocessing.py`

