### PR TITLE
Add model list endpoint and viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,21 @@ cd frontend && npm run dev
 
 Then open <http://localhost:3000/dashboard> to view the dashboard.
 
+## Model Browser
+
+The Flask API also exposes `/models`, returning a list of trained model
+directories and the files contained in each. The frontend page `/models`
+fetches this data so you can inspect what was produced by `advanced_models.py`
+or `update_models.py`.
+
+Open <http://localhost:3000/models> to view the available model files.
+
+## Prediction Chart
+
+The homepage can also visualize predictions for an entire year. Enter a year and
+click **Year Chart** to fetch monthly temperature predictions from the model
+serving API and display them using `chart.js`.
+
 ## Notifications and Support
 
 The ingestion service exposes `/alert` for posting real-time alerts and

--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -62,6 +62,22 @@ def dashboard():
     return jsonify(payload)
 
 
+@app.route("/models", methods=["GET"])
+def list_models():
+    """Return available trained models and their files."""
+    models_dir = os.getenv("MODELS_DIR", "models")
+    if not os.path.exists(models_dir):
+        return jsonify({"models": []})
+
+    entries = []
+    for name in sorted(os.listdir(models_dir)):
+        path = os.path.join(models_dir, name)
+        files = sorted(os.listdir(path)) if os.path.isdir(path) else []
+        entries.append({"name": name, "files": files})
+
+    return jsonify({"models": entries})
+
+
 @app.route("/upload", methods=["POST"])
 @jwt_required
 def upload_file():

--- a/frontend/pages/api/models/index.js
+++ b/frontend/pages/api/models/index.js
@@ -1,0 +1,11 @@
+export default async function handler(req, res) {
+  try {
+    const backend = process.env.BACKEND_URL || 'http://localhost:5000/models'
+    const resp = await fetch(backend)
+    if (!resp.ok) throw new Error('backend error')
+    const data = await resp.json()
+    res.status(200).json(data)
+  } catch (err) {
+    res.status(500).json({ error: 'failed to load models' })
+  }
+}

--- a/frontend/pages/api/predict_year.js
+++ b/frontend/pages/api/predict_year.js
@@ -1,0 +1,19 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'method not allowed' });
+    return;
+  }
+
+  try {
+    const backend = process.env.MODEL_URL || 'http://localhost:8000/predict_year';
+    const resp = await fetch(backend, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req.body),
+    });
+    const data = await resp.json();
+    res.status(resp.ok ? 200 : 500).json(data);
+  } catch (err) {
+    res.status(500).json({ error: 'failed to fetch predictions' });
+  }
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,4 +1,25 @@
 import { useState } from 'react';
+import { Line } from 'react-chartjs-2'
+import {
+    Chart as ChartJS,
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    Title,
+    Tooltip,
+    Legend,
+} from 'chart.js'
+
+ChartJS.register(
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    Title,
+    Tooltip,
+    Legend
+)
 import { getSession } from 'next-auth/react'
 
 export async function getServerSideProps(context) {
@@ -13,6 +34,7 @@ export default function Home() {
     const [year, setYear] = useState('');
     const [month, setMonth] = useState('');
     const [prediction, setPrediction] = useState(null);
+    const [chartData, setChartData] = useState(null)
 
     const handleSubmit = async (e) => {
         e.preventDefault();
@@ -24,6 +46,28 @@ export default function Home() {
         const json = await res.json();
         setPrediction(json.predicted_avg_temp);
     };
+
+    const loadChart = async () => {
+        const res = await fetch('/api/predict_year', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ year: parseInt(year) }),
+        })
+        const json = await res.json()
+        if (res.ok) {
+            setChartData({
+                labels: Array.from({ length: 12 }, (_, i) => i + 1),
+                datasets: [
+                    {
+                        label: `Predicted Avg Temp ${year}`,
+                        data: json.predictions,
+                        fill: false,
+                        tension: 0.1,
+                    },
+                ],
+            })
+        }
+    }
 
     return (
         <div className="max-w-md mx-auto mt-10">
@@ -43,18 +87,31 @@ export default function Home() {
                     onChange={(e) => setMonth(e.target.value)}
                     className="border p-2 w-full"
                 />
-                <button
-                    type="submit"
-                    className="bg-blue-500 text-white px-4 py-2 rounded"
-                >
-                    Predict
-                </button>
+                <div className="flex space-x-2">
+                    <button
+                        type="submit"
+                        className="bg-blue-500 text-white px-4 py-2 rounded"
+                    >
+                        Predict
+                    </button>
+                    <button
+                        type="button"
+                        onClick={loadChart}
+                        className="bg-blue-500 text-white px-4 py-2 rounded"
+                    >
+                        Year Chart
+                    </button>
+                </div>
             </form>
             {prediction !== null && (
                 <div className="mt-6 p-4 bg-green-100 rounded">
                     Predicted Average Temperature: {prediction.toFixed(2)}
                 </div>
             )}
+            {chartData && (
+                <div className="mt-6">
+                    <Line data={chartData} options={{ responsive: true }} />
+                </div>
+            )}
         </div>
-    );
-}
+    );}

--- a/frontend/pages/models.js
+++ b/frontend/pages/models.js
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+
+export default function Models() {
+  const [models, setModels] = useState(null)
+
+  useEffect(() => {
+    fetch('/api/models')
+      .then(res => res.json())
+      .then(data => setModels(data.models))
+      .catch(err => console.error('Error loading models:', err))
+  }, [])
+
+  if (!models) return <p>Loading models…</p>
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Trained Models</h1>
+      <ul className="list-disc pl-4">
+        {models.map(m => (
+          <li key={m.name}>
+            <strong>{m.name}</strong>
+            <ul className="list-disc pl-6">
+              {m.files.map(f => (
+                <li key={f}>{f}</li>
+              ))}
+            </ul>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/model_serving/app.py
+++ b/model_serving/app.py
@@ -6,7 +6,7 @@ import pandas as pd
 # Load trained model
 model = joblib.load("models/temperature_model.joblib")
 app = Flask(__name__)
-CORS(app, resources={r"/predict": {"origins": "http://localhost:3000"}})
+CORS(app, resources={r"/predict*": {"origins": "http://localhost:3000"}})
 
 
 @app.route("/predict", methods=["POST", "OPTIONS"])
@@ -22,6 +22,21 @@ def predict():
     df = pd.DataFrame([[year, month]], columns=["year", "month"])
     pred = model.predict(df)[0]
     return jsonify({"predicted_avg_temp": float(pred)})
+
+
+@app.route("/predict_year", methods=["POST", "OPTIONS"])
+def predict_year():
+    """Return predictions for all months of a given year."""
+    if request.method == "OPTIONS":
+        return make_response("", 204)
+    data = request.get_json()
+    year = data.get("year")
+    if year is None:
+        return jsonify({"error": "year required"}), 400
+    months = list(range(1, 13))
+    df = pd.DataFrame([[year, m] for m in months], columns=["year", "month"])
+    preds = model.predict(df)
+    return jsonify({"year": year, "predictions": [float(p) for p in preds]})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- serve trained model metadata via `/models` in Flask API
- display model files on new `/models` Next.js page
- expose backend via `/api/models` route
- document the model browser in README
- add yearly prediction chart on homepage
